### PR TITLE
bug: use -R option instead of -ra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_deploy:
   - git config --local user.name "uobikiemukot"
   - git config --local user.email "uobikiemukot@gmail.com"
   - git tag "travis-${RELEASE_ID}"
-  - cp -ra build/Release/yaft-cocoa.app .
+  - cp -R build/Release/yaft-cocoa.app .
   - tar cfz ${RELEASE_FILE} yaft-cocoa.app
 deploy:
   provider: releases


### PR DESCRIPTION
~~~
$ cp -ra build/Release/yaft-cocoa.app .
cp: the -R and -r options may not be specified together.
The command "cp -ra build/Release/yaft-cocoa.app ." failed and exited with 1 during .
~~~